### PR TITLE
カタリスト一覧画面に検索機能の追加

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -54,12 +54,22 @@ class UsersController extends AppController
         if ($this->Auth->user('id') > 0) {
             $conditions['id !='] = $this->Auth->user('id');
         }
+
+        $search_text = '';
+        if ($this->request->query('search')) {
+            // 重い検索なので暫定
+            $tmp['disp_name LIKE'] = '%' . $this->request->query('search') . '%';
+            $tmp['catch_phrase LIKE'] = '%' . $this->request->query('search') . '%';
+            $tmp['description LIKE'] = '%' . $this->request->query('search') . '%';
+            $conditions['OR'] = $tmp;
+            $search_text = $this->request->query('search');
+        }
         $this->paginate = [
             'conditions' => $conditions,
         ];
         $users = $this->paginate($this->Users);
 
-        $this->set(compact('users'));
+        $this->set(compact('users', 'search_text'));
     }
 
     /**

--- a/src/Template/Users/index.ctp
+++ b/src/Template/Users/index.ctp
@@ -6,6 +6,13 @@
 ?>
 <div class="users index columns content">
     <h3><?= __('Users') ?></h3>
+    <div class="">
+        <?= $this->Form->create(null, ['type' => 'get']) ?>
+        <?= $this->Form->text('search', ['value' => h($search_text) ?? '', 'placeholder' => '例：人事']) ?>
+        <?= $this->Form->submit('検索') ?>
+        <?= $this->Html->link('検索条件をクリア', ['action' => 'index']) ?>
+        <?= $this->Form->end() ?>
+    </div>
     <table cellpadding="0" cellspacing="0">
         <thead>
             <tr>


### PR DESCRIPTION
表示名・キャッチフレーズ・詳細の文言の部分一致で検索できるようにしました。
※現在の仕様はデータが増えると遅くなるので後で見直す