### PR TITLE
mysql5.7のdockerコンテナを手元で立ち上げるためのdocker-composeファイルを追加

### DIFF
--- a/docker-compose-db.yml
+++ b/docker-compose-db.yml
@@ -1,0 +1,12 @@
+version: "3.1"
+services:
+  db:
+    image: mysql:5.7
+    entrypoint: docker-entrypoint.sh --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: katalist_dev
+      MYSQL_USER: katalist
+      MYSQL_PASSWORD: password
+    ports:
+    - 3306:3306


### PR DESCRIPTION
僕の手元作業用ファイルで申し訳ないのですがmyqlのコンテナを立ち上げるためのファイル追加しました。
