### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@
 /logs/*
 /tmp/*
 /vendor/*
+/webroot/files
 /webroot/files/*
-!/webroot/files/empty
 
 # OS generated files #
 ######################


### PR DESCRIPTION
/webroot/files をsymbolic linkで紐付ける運用にした場合、"!/webroot/files/empty"の指定がsymblic linkを超えた指定になるので、gitでうまく扱えない為削除。（元々symbolic linkの指定を削除したことにより本指定は不要になったので内容的にも不要。）